### PR TITLE
SIANXKE-292: Add UNIX socket and URL support for redis connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for UNIX socket redis connections
+- Generating redis configurations from a given URL
 
 ## [1.0.3] - 2022-01-19
 ### Changed

--- a/README.md
+++ b/README.md
@@ -149,6 +149,24 @@ with concurrency_limit.limit(redis_configuration, limit_configuration):
     do_something_magic()
 ```
 
+### Example 6
+
+Limit the concurrency group `"example-6"` to `100` concurrently running scopes. A redis URL will be used instead of
+separately specifying host and port for the redis connection.
+
+```python
+import concurrency_limit
+
+redis_configuration = concurrency_limit.RedisConfiguration.from_url('redis://127.0.0.1:6379/0')
+limit_configuration = concurrency_limit.LimitConfiguration(
+    key='example-6',
+    limit=100,
+)
+
+with concurrency_limit.limit(redis_configuration, limit_configuration):
+    do_something_magic()
+```
+
 ## Configuration options
 
 ### `RedisConfiguration`
@@ -164,6 +182,12 @@ The hostname or IP of the Redis server.
 Default: `6379`
 
 The Redis server port.
+
+#### `path: str`
+
+Default: `None`
+
+The socket path used if `unix_socket` is set.
 
 #### `db: int`
 
@@ -201,12 +225,24 @@ Default: `False`
 
 Use secure connection to Redis server.
 
+#### `unix_socket: bool`
+
+Default: `False`
+
+Use UNIX socket connection to Redis server. Will ignore `secure`, if set as there is no SSL mode with sockets.
+
+#### `connection_class: typing.Type[redis.Connection]`
+
+Default: `None`
+
+Redis connection class to use instead of `secure` and `unix_socket` fields, if set.
+
 #### `connection_pool: redis.ConnectionPool`
 
 Default: `None`
 
 Use this connection pool instance instead of the other fields, if set. All other fields of the configuration
-instance is ignored in this case.
+instance are ignored in this case.
 
 ### `LimitConfiguration`
 

--- a/concurrency_limit/_connections.py
+++ b/concurrency_limit/_connections.py
@@ -43,12 +43,13 @@ def _get_redis_by_credentials(configuration: RedisConfiguration) -> redis.Redis:
             _connection_pool_map[configuration] = redis.BlockingConnectionPool(
                 host=configuration.host,
                 port=configuration.port,
+                path=configuration.path,
                 db=configuration.db,
                 username=configuration.username,
                 password=configuration.password,
                 max_connections=configuration.max_connections,
                 timeout=configuration.timeout,
-                connection_class=redis.SSLConnection if configuration.secure else redis.Connection,
+                connection_class=configuration.get_connection_class(),
             )
 
         return redis.Redis(connection_pool=_connection_pool_map[configuration])

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # Development dependencies
 pytest>=6.2,<6.3
 pytest-mock>=3.6,<3.7
-flake8>=3.9,<3.10
+flake8>=5.0.0,<5.1.0
 codecov>=2.1,<2.2
 setuptools>=42
 wheel>=0.37

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,0 +1,53 @@
+import typing
+
+import pytest
+import redis.connection
+
+from concurrency_limit import RedisConfiguration
+
+
+@pytest.mark.parametrize('url,config', [
+    (
+            'redis://127.0.0.1:6379/1', 
+            RedisConfiguration(host='127.0.0.1', port=6379, db=1)
+    ),
+    (
+            'redis://test-user:test-pw@127.0.0.1:6379/1', 
+            RedisConfiguration(host='127.0.0.1', port=6379, db=1, username='test-user', password='test-pw')
+    ),
+    (
+            'rediss://127.0.0.1:6379/1', 
+            RedisConfiguration(host='127.0.0.1', port=6379, db=1, connection_class=redis.SSLConnection)
+    ),
+    (
+            'rediss://test-user:test-pw@127.0.0.1:6379/1',
+            RedisConfiguration(host='127.0.0.1', port=6379, db=1, username='test-user', password='test-pw',
+                               connection_class=redis.SSLConnection)
+    ),
+    (
+            'unix:///run/redis.sock?db=1',
+            RedisConfiguration(path='/run/redis.sock', port=6379, db=1,
+                               connection_class=redis.UnixDomainSocketConnection)
+    ),
+    (
+            'unix://test-user:test-pw@/run/redis.sock?db=1',
+            RedisConfiguration(path='/run/redis.sock', port=6379, db=1,  username='test-user', password='test-pw',
+                               connection_class=redis.UnixDomainSocketConnection)
+    ),
+])
+def test_configuration_from_url(url: str, config: RedisConfiguration):
+    assert RedisConfiguration.from_url(url) == config
+
+
+@pytest.mark.parametrize('config,expected_class', [
+    (RedisConfiguration(), redis.Connection),
+    (RedisConfiguration(secure=True), redis.SSLConnection),
+    (RedisConfiguration(unix_socket=True), redis.UnixDomainSocketConnection),
+    (RedisConfiguration(connection_class=redis.Connection), redis.Connection),
+    (RedisConfiguration(connection_class=redis.SSLConnection), redis.SSLConnection),
+    (RedisConfiguration(connection_class=redis.UnixDomainSocketConnection), redis.UnixDomainSocketConnection),
+    (RedisConfiguration(secure=True, unix_socket=True), redis.UnixDomainSocketConnection),
+    (RedisConfiguration(secure=True, unix_socket=True, connection_class=redis.Connection), redis.Connection),
+])
+def test_configuration_get_connection_class(config: RedisConfiguration, expected_class: typing.Type[redis.Connection]):
+    assert config.get_connection_class() == expected_class


### PR DESCRIPTION
**Changes**

- Add unix socket configuration fields
- Add redis `connection class` configuration field
- Add method to determine the right `connection_class` to use
- Implement `from_url` in the same way as `redis-py` does it
- Add unit tests for the new methods on the configuration class
- Updated `flake8` to fix `importlib-metadata` breaking changes