### PR TITLE
SIANXSVC-1055: Individual concurrency locks expire despite connection errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.7"
-          - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for UNIX socket redis connections
 - Generating redis configurations from a given URL
 
+### Changed
+- Minimum required version of `redis-py` is now `4.0`
+
+### Removed
+- Removed support for Python 3.7 and Python 3.8
+
+### Fixed
+- Individual concurrency locks expire despite connection errors
+
 ## [1.0.3] - 2022-01-19
 ### Changed
 - Updated badges

--- a/README.md
+++ b/README.md
@@ -284,11 +284,11 @@ configured time, it will be deleted.
 
 |             | Supported |
 |-------------|-----------|
-| Python 3.7  | ✓         |
-| Python 3.8  | ✓         |
 | Python 3.9  | ✓         |
 | Python 3.10 | ✓         |
+| Python 3.11 | ✓         |
 
 # List of developers
 
-* Andreas Stocker <AStocker@anexia-it.com>, Lead Developer
+* Andreas Stocker <AStocker@anexia.com>, Lead Developer
+* Patrick Taibel <PTaibel@anexia.com>, Developer

--- a/concurrency_limit/_connections.py
+++ b/concurrency_limit/_connections.py
@@ -1,17 +1,17 @@
+import functools
 import threading
+
 import redis
 
 from .configuration import *
 
-
-__all__ = [
-    'get_redis',
-]
+__all__ = ["get_redis"]
 
 _connection_pool_map = {}
 _connection_pool_lock = threading.Lock()
 
 
+@functools.cache
 def get_redis(configuration: RedisConfiguration) -> redis.Redis:
     """
     Gets the Redis client used to store the concurrency keys.

--- a/concurrency_limit/configuration.py
+++ b/concurrency_limit/configuration.py
@@ -3,11 +3,7 @@ import typing
 
 import redis
 
-
-__all__ = [
-    'RedisConfiguration',
-    'LimitConfiguration',
-]
+__all__ = ["RedisConfiguration", "LimitConfiguration"]
 
 
 @dataclasses.dataclass(eq=True, frozen=True)
@@ -15,6 +11,7 @@ class RedisConfiguration:
     """
     Redis connection configuration.
     """
+
     host: str = None
     "The hostname or IP of the Redis server."
 
@@ -92,8 +89,8 @@ class RedisConfiguration:
         """
         url_options = redis.connection.parse_url(url)
 
-        if 'connection_class' in kwargs:
-            url_options['connection_class'] = kwargs['connection_class']
+        if "connection_class" in kwargs:
+            url_options["connection_class"] = kwargs["connection_class"]
 
         kwargs.update(url_options)
         return cls(**kwargs)
@@ -104,6 +101,7 @@ class LimitConfiguration:
     """
     Concurrency limit configuration.
     """
+
     key: str
     "The concurrency limit group identifier."
 

--- a/concurrency_limit/context_managers.py
+++ b/concurrency_limit/context_managers.py
@@ -1,78 +1,140 @@
 import contextlib
 import time
+import uuid
 
 from ._connections import *
 from .configuration import *
 from .exceptions import *
 
-
-__all__ = [
-    'limit',
-]
+__all__ = ["limit", "limit_clean", "limit_iter"]
 
 
 @contextlib.contextmanager
 def limit(
-        redis_configuration: RedisConfiguration,
-        limit_configuration: LimitConfiguration,
+    redis_configuration: RedisConfiguration, limit_configuration: LimitConfiguration
 ):
     """
-    Context manager that limits concurrency within its scope as defined on the given limit configuration. This is
-    done with the logic as follows:
-     - If the count of concurrently running scopes is below the configured limit, the scope is executed immediately.
-     - If the count of concurrently running scopes exceeds the configured limit, the context manager wait unit it
-       goes below the configured limit.
-     - If the count of concurrently running scopes does not go below the configured limit with the configured
-       timeout, a `ConcurrencyLimitExceededException` exception is raised.
+    The `limit` method is a context manager that allows for executing a scoped block of code under a concurrency limit.
+    It prevents more than a certain number of executions of the scoped block at a time.
 
-    :param redis_configuration: Redis configuration
-    :param limit_configuration: Limit configuration
-    :raise ConcurrencyLimitExceededException: Configured concurrency limit not under-run within configured timeout
-    :return:
+    Example usage:
+
+        from concurrency_limit import *
+
+        redis_configuration = RedisConfiguration(host='localhost', port=6379)
+        limit_configuration = LimitConfiguration(key='my_key', limit=5, limit_timeout=10, limit_expire=30)
+
+        with limit(redis_configuration, limit_configuration) as count:
+            # Scoped block of code that will be executed under the concurrency limit.
+            print(f"Executing the scoped block of code. Current count: {count}")
+
+    The method acquires an execution slot by increasing a concurrency counter stored in Redis, and checks if the
+    counter is below the configured limit. If the limit is exceeded, the method waits for the configured interval
+    before trying again. If the configured timeout is reached, a `ConcurrencyLimitExceededException` is raised. Upon
+    exiting the scoped block, the context manager releases the execution slot and updates the concurrency counter
+    in Redis accordingly.
+
+    Note: Any exceptions raised within the scoped block will propagate outside the scope of the `limit` method.
+
+    :param redis_configuration: RedisConfiguration object containing the configuration details for connecting to Redis.
+    :param limit_configuration: LimitConfiguration object containing the configuration details for the limit.
     """
+
+    class _LockAcquireException(Exception):
+        pass
+
     client = get_redis(redis_configuration)
-    start = time.time()
-    executed = False
+
+    start = time.monotonic()
+
+    lock_limit = limit_configuration.limit
+    lock_key = limit_configuration.key
+    lock_expire = limit_configuration.limit_expire
+    lock_timeout = limit_configuration.limit_timeout
+    lock_interval = limit_configuration.limit_interval
+    lock_id = str(uuid.uuid4())
 
     try:
-        # we loop as long as it was not possible to execute the context manager's scope.
-        while not executed:
-            # first we try to acquire an execution slot by increasing the concurrency counter and checking if the
-            # counter is below the configured limit. if it is, we execute the scope. if it is not, we immediately
-            # decrease the concurrency counter as we are not able to execute the scope.
-            count = client.incr(limit_configuration.key, 1)
-            client.expire(limit_configuration.key, limit_configuration.limit_expire)
+        # We loop as long as it was not possible to execute the context manager's scope.
+        while True:
+            try:
+                # First we check if we should try to acquire an execution slot. If the limit is already exceeded,
+                # there is no need to set the lock-key.
+                count = client.hlen(lock_key)
+                if count >= lock_limit:
+                    raise _LockAcquireException()
 
-            # if there is no available execution slot.
-            if count > limit_configuration.limit:
-                client.decr(limit_configuration.key, 1)
-                elapsed = time.time() - start
+                # We have the chance to acquire a slot, so we set current id on the lock-key. After doing so, we
+                # re-check the number of acquired slots, and are re-trying if we now exceeded the limit.
+                count = (
+                    client.pipeline()
+                    .hset(lock_key, lock_id, int(time.time()) + lock_expire)
+                    .expire(lock_key, lock_expire)
+                    .hlen(lock_key)
+                    .execute()[-1]
+                )
 
-                # if we are waiting longer than the configured timeout, we raise a `ConcurrencyLimitExceededException`
-                # exception. executing the context manager's scope failed in this case.
-                if elapsed > limit_configuration.limit_timeout:
+                if count > lock_limit:
+                    client.hdel(lock_key, lock_id)
+                    raise _LockAcquireException()
+
+                # Now we are in the critical section and yield to the context manager's scope.
+                yield count
+                break
+
+            except _LockAcquireException:
+                elapsed = time.monotonic() - start
+
+                # If we are waiting longer than the configured timeout, we raise a `ConcurrencyLimitExceededException`
+                # exception. Executing the context manager's scope failed in this case.
+                if elapsed > lock_timeout:
                     raise ConcurrencyLimitExceededException(
-                        limit=limit_configuration.limit,
-                        timeout=limit_configuration.limit_timeout,
+                        limit=lock_limit, timeout=lock_timeout
                     )
 
-                # we failed to acquire an execution slot for the context manager's scope, but we want to try again.
-                # however, we wait the configured interval before we do so.
-                time.sleep(limit_configuration.limit_interval)
-
-            # if we successfully acquired an execution slot for the context manager's scope.
-            else:
-                executed = True
-                yield count
+                # We failed to acquire an execution slot for the context manager's scope, but we want to try again.
+                # However, we wait the configured interval before we do so.
+                time.sleep(lock_interval)
 
     finally:
-        if executed:
-            client.setnx(limit_configuration.key, 1)
-            count = client.decr(limit_configuration.key, 1)
+        client.hdel(lock_key, lock_id)
 
-            # if there are nested concurrency contexts on the same key, and the outer concurrency timed out, we might
-            # end up with a negative count. we reset to 0 if this happens.
-            if count < 0:
-                client.decr(limit_configuration.key, count)
 
-        del client
+def limit_clean(
+    redis_configuration: RedisConfiguration, limit_configuration: LimitConfiguration
+):
+    """
+    Cleans stale limit locks in the hash for the given limit configuration.
+
+    :param redis_configuration: RedisConfiguration object containing the configuration details for connecting to Redis.
+    :param limit_configuration: LimitConfiguration object containing the configuration details for the limit.
+    :return: Number of cleaned items
+    """
+    client = get_redis(redis_configuration)
+    current = int(time.time())
+    count = 0
+
+    lock_key = limit_configuration.key
+
+    for scan_lock_id, scan_lock_expire in client.hscan_iter(lock_key):
+        try:
+            clean_lock = current >= int(scan_lock_expire)
+        except (ValueError, TypeError):
+            clean_lock = True
+
+        if clean_lock:
+            count += client.hdel(lock_key, scan_lock_id)
+
+    return count
+
+
+def limit_iter(redis_configuration: RedisConfiguration, key_pattern: str):
+    """
+    Return an iterator over the items in Redis specified by `key_pattern`
+    using the Redis connection specified by `redis_configuration`.
+
+    :param redis_configuration: The configuration for connecting to Redis.
+    :param key_pattern: The pattern for Redis to iterate over.
+    :return: Scan Iterator
+    """
+    return get_redis(redis_configuration).scan_iter(key_pattern)

--- a/concurrency_limit/exceptions.py
+++ b/concurrency_limit/exceptions.py
@@ -1,20 +1,18 @@
-__all__ = [
-    'ConcurrencyLimitException',
-    'ConcurrencyLimitExceededException',
-]
+__all__ = ["ConcurrencyLimitException", "ConcurrencyLimitExceededException"]
 
 
 class ConcurrencyLimitException(Exception):
     """
     Base class for all concurrency limit related exceptions.
     """
+
     _msg_template = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(
-            self._msg_template.format(*args, **kwargs) if self._msg_template else None,
+            self._msg_template.format(*args, **kwargs) if self._msg_template else None
         )
 
 
 class ConcurrencyLimitExceededException(ConcurrencyLimitException):
-    _msg_template = 'Exceeded the concurrency limit of {limit} executions. Waited for {timeout} seconds.'
+    _msg_template = "Exceeded the concurrency limit of {limit} executions. Waited for {timeout} seconds."

--- a/setup.py
+++ b/setup.py
@@ -2,38 +2,35 @@ import os
 
 from setuptools import find_packages, setup
 
-with open(os.path.join(os.path.dirname(__file__), 'README.md')) as fh:
+with open(os.path.join(os.path.dirname(__file__), "README.md")) as fh:
     readme = fh.read()
 
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
-    name='concurrency-limit',
-    version=os.getenv('PACKAGE_VERSION', '0.0.0').replace('refs/tags/', ''),
+    name="concurrency-limit",
+    version=os.getenv("PACKAGE_VERSION", "0.0.0").replace("refs/tags/", ""),
     packages=find_packages(),
     include_package_data=True,
-    license='MIT',
-    description='A library that implements a distributed concurrency limiting mechanism using Redis as a backend.',
+    license="MIT",
+    description="A library that implements a distributed concurrency limiting mechanism using Redis as a backend.",
     long_description=readme,
-    long_description_content_type='text/markdown',
-    url='https://github.com/anexia/python-concurrency-limit',
-    author='Andreas Stocker',
-    author_email='AStocker@anexia-it.com',
-    install_requires=[
-        'redis>=3.5',
-    ],
+    long_description_content_type="text/markdown",
+    url="https://github.com/anexia/python-concurrency-limit",
+    author="Andreas Stocker",
+    author_email="AStocker@anexia.com",
+    install_requires=["redis>=4.0"],
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Topic :: Software Development',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Topic :: Software Development",
     ],
 )

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,65 +1,103 @@
-import time
-import threading
 import collections
+import fnmatch
 import functools
+import threading
+import time
 
-
-__all__ = [
-    'RedisMock',
-    'concurrent',
-]
+__all__ = ["RedisMock", "concurrent"]
 
 
 class RedisMock:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._hashes = collections.defaultdict(lambda: {})
+        self._expires = collections.defaultdict(lambda: time.time() + 2 ** 32)
 
-    _lock = threading.Lock()
-    _keys = collections.defaultdict(lambda: 0)
-    _expires = collections.defaultdict(lambda: time.time() + 2 ** 32)
+    def scan_iter(self, match):
+        for key in fnmatch.filter(self._hashes.keys(), match):
+            yield key
 
-    def incr(self, name, amount=1):
+    def hlen(self, name):
         with self._lock:
-            if time.time() > self._expires[name]:
-                del self._keys[name]
-                del self._expires[name]
+            self._clean_expired(name)
+            return len(self._hashes[name])
 
-            self._keys[name] += amount
-            return self._keys[name]
-
-    def decr(self, name, amount=1):
-        return self.incr(name, amount=amount * -1)
-
-    def setnx(self, name, value):
+    def hset(self, name, key, value):
         with self._lock:
-            if time.time() > self._expires[name]:
-                del self._keys[name]
-                del self._expires[name]
+            self._hashes[name][key] = str(value)
 
-            if name not in self._keys:
-                self._keys[name] = value
-                return 1
-            return 0
+    def hdel(self, name, *keys):
+        count = 0
 
-    def expire(self, name, ttl):
         with self._lock:
-            if name in self._keys:
-                self._expires[name] = time.time() + ttl
-                return 1
-            return 0
+            for key in keys:
+                try:
+                    del self._hashes[name][key]
+                    count += 1
+                except KeyError:
+                    pass
+
+        return count
+
+    def hscan_iter(self, name):
+        with self._lock:
+            self._clean_expired(name)
+            _hash = dict(self._hashes[name])
+
+        for hkey, hvalue in _hash.items():
+            yield hkey, hvalue
+
+    def expire(self, name, _time):
+        with self._lock:
+            self._expires[name] = _time + time.time()
+
+    def pipeline(self):
+        client = self
+
+        class _Pipeline:
+            def __init__(self):
+                self.buffer = []
+
+            def __getattr__(self, item):
+                def _wrapper(*args, **kwargs):
+                    self.buffer.append(wrapped(*args, **kwargs))
+                    return self
+
+                wrapped = getattr(client, item)
+
+                return _wrapper
+
+            def execute(self):
+                try:
+                    return self.buffer
+                finally:
+                    self.buffer = []
+
+        return _Pipeline()
+
+    def _clean_expired(self, name):
+        if time.time() > self._expires[name]:
+            del self._expires[name]
+
+            try:
+                del self._hashes[name]
+            except KeyError:
+                pass
 
 
 def concurrent(threads: int):
     class ExceptionAwareThread(threading.Thread):
         def run(self):
             try:
-                setattr(self, '_ret', self._target(*self._args, **self._kwargs))
+                setattr(self, "_ret", self._target(*self._args, **self._kwargs))
             except BaseException as e:
-                setattr(self, '_exc', e)
+                setattr(self, "_exc", e)
 
         def join(self, timeout=None):
             super().join(timeout=timeout)
 
-            exc = getattr(self, '_exc', None)
-            ret = getattr(self, '_ret', None)
+            exc = getattr(self, "_exc", None)
+            ret = getattr(self, "_ret", None)
 
             if exc:
                 raise exc

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,53 +1,97 @@
 import typing
 
-import pytest
 import redis.connection
+
+import pytest
 
 from concurrency_limit import RedisConfiguration
 
 
-@pytest.mark.parametrize('url,config', [
-    (
-            'redis://127.0.0.1:6379/1', 
-            RedisConfiguration(host='127.0.0.1', port=6379, db=1)
-    ),
-    (
-            'redis://test-user:test-pw@127.0.0.1:6379/1', 
-            RedisConfiguration(host='127.0.0.1', port=6379, db=1, username='test-user', password='test-pw')
-    ),
-    (
-            'rediss://127.0.0.1:6379/1', 
-            RedisConfiguration(host='127.0.0.1', port=6379, db=1, connection_class=redis.SSLConnection)
-    ),
-    (
-            'rediss://test-user:test-pw@127.0.0.1:6379/1',
-            RedisConfiguration(host='127.0.0.1', port=6379, db=1, username='test-user', password='test-pw',
-                               connection_class=redis.SSLConnection)
-    ),
-    (
-            'unix:///run/redis.sock?db=1',
-            RedisConfiguration(path='/run/redis.sock', port=6379, db=1,
-                               connection_class=redis.UnixDomainSocketConnection)
-    ),
-    (
-            'unix://test-user:test-pw@/run/redis.sock?db=1',
-            RedisConfiguration(path='/run/redis.sock', port=6379, db=1,  username='test-user', password='test-pw',
-                               connection_class=redis.UnixDomainSocketConnection)
-    ),
-])
+@pytest.mark.parametrize(
+    "url,config",
+    [
+        (
+            "redis://127.0.0.1:6379/1",
+            RedisConfiguration(host="127.0.0.1", port=6379, db=1),
+        ),
+        (
+            "redis://test-user:test-pw@127.0.0.1:6379/1",
+            RedisConfiguration(
+                host="127.0.0.1",
+                port=6379,
+                db=1,
+                username="test-user",
+                password="test-pw",
+            ),
+        ),
+        (
+            "rediss://127.0.0.1:6379/1",
+            RedisConfiguration(
+                host="127.0.0.1", port=6379, db=1, connection_class=redis.SSLConnection
+            ),
+        ),
+        (
+            "rediss://test-user:test-pw@127.0.0.1:6379/1",
+            RedisConfiguration(
+                host="127.0.0.1",
+                port=6379,
+                db=1,
+                username="test-user",
+                password="test-pw",
+                connection_class=redis.SSLConnection,
+            ),
+        ),
+        (
+            "unix:///run/redis.sock?db=1",
+            RedisConfiguration(
+                path="/run/redis.sock",
+                port=6379,
+                db=1,
+                connection_class=redis.UnixDomainSocketConnection,
+            ),
+        ),
+        (
+            "unix://test-user:test-pw@/run/redis.sock?db=1",
+            RedisConfiguration(
+                path="/run/redis.sock",
+                port=6379,
+                db=1,
+                username="test-user",
+                password="test-pw",
+                connection_class=redis.UnixDomainSocketConnection,
+            ),
+        ),
+    ],
+)
 def test_configuration_from_url(url: str, config: RedisConfiguration):
     assert RedisConfiguration.from_url(url) == config
 
 
-@pytest.mark.parametrize('config,expected_class', [
-    (RedisConfiguration(), redis.Connection),
-    (RedisConfiguration(secure=True), redis.SSLConnection),
-    (RedisConfiguration(unix_socket=True), redis.UnixDomainSocketConnection),
-    (RedisConfiguration(connection_class=redis.Connection), redis.Connection),
-    (RedisConfiguration(connection_class=redis.SSLConnection), redis.SSLConnection),
-    (RedisConfiguration(connection_class=redis.UnixDomainSocketConnection), redis.UnixDomainSocketConnection),
-    (RedisConfiguration(secure=True, unix_socket=True), redis.UnixDomainSocketConnection),
-    (RedisConfiguration(secure=True, unix_socket=True, connection_class=redis.Connection), redis.Connection),
-])
-def test_configuration_get_connection_class(config: RedisConfiguration, expected_class: typing.Type[redis.Connection]):
+@pytest.mark.parametrize(
+    "config,expected_class",
+    [
+        (RedisConfiguration(), redis.Connection),
+        (RedisConfiguration(secure=True), redis.SSLConnection),
+        (RedisConfiguration(unix_socket=True), redis.UnixDomainSocketConnection),
+        (RedisConfiguration(connection_class=redis.Connection), redis.Connection),
+        (RedisConfiguration(connection_class=redis.SSLConnection), redis.SSLConnection),
+        (
+            RedisConfiguration(connection_class=redis.UnixDomainSocketConnection),
+            redis.UnixDomainSocketConnection,
+        ),
+        (
+            RedisConfiguration(secure=True, unix_socket=True),
+            redis.UnixDomainSocketConnection,
+        ),
+        (
+            RedisConfiguration(
+                secure=True, unix_socket=True, connection_class=redis.Connection
+            ),
+            redis.Connection,
+        ),
+    ],
+)
+def test_configuration_get_connection_class(
+    config: RedisConfiguration, expected_class: typing.Type[redis.Connection]
+):
     assert config.get_connection_class() == expected_class

--- a/tests/test_limit.py
+++ b/tests/test_limit.py
@@ -1,38 +1,39 @@
 import time
+
 import pytest
 import pytest_mock
+
 import concurrency_limit
 
 from test_base import *
 
 
 def test_limit_without_concurrency(mocker: pytest_mock.MockerFixture):
-    mocker.patch('concurrency_limit.context_managers.get_redis', return_value=RedisMock())
+    mocker.patch(
+        "concurrency_limit.context_managers.get_redis", return_value=RedisMock()
+    )
 
     with concurrency_limit.limit(
-            concurrency_limit.RedisConfiguration(),
-            concurrency_limit.LimitConfiguration(
-                key='key-1',
-                limit=1,
-            ),
+        concurrency_limit.RedisConfiguration(),
+        concurrency_limit.LimitConfiguration(key="key-1", limit=1),
     ) as slot_id:
         assert slot_id == 1
 
 
 def test_limit_slot_ids(mocker: pytest_mock.MockerFixture):
-    mocker.patch('concurrency_limit.context_managers.get_redis', return_value=RedisMock())
+    mocker.patch(
+        "concurrency_limit.context_managers.get_redis", return_value=RedisMock()
+    )
 
     slot_ids = []
 
     @concurrent(threads=10)
     def _concurrent_function():
         with concurrency_limit.limit(
-                concurrency_limit.RedisConfiguration(),
-                concurrency_limit.LimitConfiguration(
-                    key='key-1',
-                    limit=10,
-                    limit_timeout=0,
-                ),
+            concurrency_limit.RedisConfiguration(),
+            concurrency_limit.LimitConfiguration(
+                key="key-1", limit=10, limit_timeout=0
+            ),
         ) as slot_id:
             slot_ids.append(slot_id)
             time.sleep(1)
@@ -44,17 +45,15 @@ def test_limit_slot_ids(mocker: pytest_mock.MockerFixture):
 
 
 def test_limit_within_limit(mocker: pytest_mock.MockerFixture):
-    mocker.patch('concurrency_limit.context_managers.get_redis', return_value=RedisMock())
+    mocker.patch(
+        "concurrency_limit.context_managers.get_redis", return_value=RedisMock()
+    )
 
     @concurrent(threads=1)
     def _concurrent_function():
         with concurrency_limit.limit(
-                concurrency_limit.RedisConfiguration(),
-                concurrency_limit.LimitConfiguration(
-                    key='key-1',
-                    limit=1,
-                    limit_timeout=0,
-                ),
+            concurrency_limit.RedisConfiguration(),
+            concurrency_limit.LimitConfiguration(key="key-1", limit=1, limit_timeout=0),
         ):
             time.sleep(1)
 
@@ -62,17 +61,15 @@ def test_limit_within_limit(mocker: pytest_mock.MockerFixture):
 
 
 def test_limit_exceeded_limit_without_timeout(mocker: pytest_mock.MockerFixture):
-    mocker.patch('concurrency_limit.context_managers.get_redis', return_value=RedisMock())
+    mocker.patch(
+        "concurrency_limit.context_managers.get_redis", return_value=RedisMock()
+    )
 
     @concurrent(threads=10)
     def _concurrent_function():
         with concurrency_limit.limit(
-                concurrency_limit.RedisConfiguration(),
-                concurrency_limit.LimitConfiguration(
-                    key='key-1',
-                    limit=1,
-                    limit_timeout=0,
-                ),
+            concurrency_limit.RedisConfiguration(),
+            concurrency_limit.LimitConfiguration(key="key-1", limit=1, limit_timeout=0),
         ):
             time.sleep(1)
 
@@ -81,17 +78,15 @@ def test_limit_exceeded_limit_without_timeout(mocker: pytest_mock.MockerFixture)
 
 
 def test_limit_exceeded_limit_within_timeout(mocker: pytest_mock.MockerFixture):
-    mocker.patch('concurrency_limit.context_managers.get_redis', return_value=RedisMock())
+    mocker.patch(
+        "concurrency_limit.context_managers.get_redis", return_value=RedisMock()
+    )
 
     @concurrent(threads=10)
     def _concurrent_function():
         with concurrency_limit.limit(
-                concurrency_limit.RedisConfiguration(),
-                concurrency_limit.LimitConfiguration(
-                    key='key-1',
-                    limit=5,
-                    limit_timeout=5,
-                ),
+            concurrency_limit.RedisConfiguration(),
+            concurrency_limit.LimitConfiguration(key="key-1", limit=5, limit_timeout=5),
         ):
             time.sleep(1)
 
@@ -99,17 +94,15 @@ def test_limit_exceeded_limit_within_timeout(mocker: pytest_mock.MockerFixture):
 
 
 def test_limit_exceeded_limit_exceeded_timeout(mocker: pytest_mock.MockerFixture):
-    mocker.patch('concurrency_limit.context_managers.get_redis', return_value=RedisMock())
+    mocker.patch(
+        "concurrency_limit.context_managers.get_redis", return_value=RedisMock()
+    )
 
     @concurrent(threads=10)
     def _concurrent_function():
         with concurrency_limit.limit(
-                concurrency_limit.RedisConfiguration(),
-                concurrency_limit.LimitConfiguration(
-                    key='key-1',
-                    limit=5,
-                    limit_timeout=5,
-                ),
+            concurrency_limit.RedisConfiguration(),
+            concurrency_limit.LimitConfiguration(key="key-1", limit=5, limit_timeout=5),
         ):
             time.sleep(10)
 
@@ -118,73 +111,95 @@ def test_limit_exceeded_limit_exceeded_timeout(mocker: pytest_mock.MockerFixture
 
 
 def test_limit_within_limit_expire(mocker: pytest_mock.MockerFixture):
-    mocker.patch('concurrency_limit.context_managers.get_redis', return_value=RedisMock())
+    mocker.patch(
+        "concurrency_limit.context_managers.get_redis", return_value=RedisMock()
+    )
 
     with concurrency_limit.limit(
-            concurrency_limit.RedisConfiguration(),
-            concurrency_limit.LimitConfiguration(
-                key='key-1',
-                limit=1,
-                limit_expire=5,
-                limit_timeout=0,
-            ),
+        concurrency_limit.RedisConfiguration(),
+        concurrency_limit.LimitConfiguration(
+            key="key-1", limit=1, limit_expire=5, limit_timeout=0
+        ),
     ):
         time.sleep(1)
 
         with pytest.raises(concurrency_limit.ConcurrencyLimitException):
             with concurrency_limit.limit(
-                    concurrency_limit.RedisConfiguration(),
-                    concurrency_limit.LimitConfiguration(
-                        key='key-1',
-                        limit=1,
-                        limit_expire=5,
-                        limit_timeout=0,
-                    ),
+                concurrency_limit.RedisConfiguration(),
+                concurrency_limit.LimitConfiguration(
+                    key="key-1", limit=1, limit_expire=5, limit_timeout=0
+                ),
             ):
                 time.sleep(1)
 
 
 def test_limit_exceeded_limit_expire(mocker: pytest_mock.MockerFixture):
-    mocker.patch('concurrency_limit.context_managers.get_redis', return_value=RedisMock())
+    mocker.patch(
+        "concurrency_limit.context_managers.get_redis", return_value=RedisMock()
+    )
 
     with concurrency_limit.limit(
-            concurrency_limit.RedisConfiguration(),
-            concurrency_limit.LimitConfiguration(
-                key='key-1',
-                limit=1,
-                limit_expire=5,
-                limit_timeout=0,
-            ),
+        concurrency_limit.RedisConfiguration(),
+        concurrency_limit.LimitConfiguration(
+            key="key-1", limit=1, limit_expire=5, limit_timeout=0
+        ),
     ):
         time.sleep(10)
 
         with concurrency_limit.limit(
-                concurrency_limit.RedisConfiguration(),
-                concurrency_limit.LimitConfiguration(
-                    key='key-1',
-                    limit=1,
-                    limit_expire=5,
-                    limit_timeout=0,
-                ),
+            concurrency_limit.RedisConfiguration(),
+            concurrency_limit.LimitConfiguration(
+                key="key-1", limit=1, limit_expire=5, limit_timeout=0
+            ),
         ):
             time.sleep(1)
 
 
 def test_limit_with_high_load(mocker: pytest_mock.MockerFixture):
-    mocker.patch('concurrency_limit.context_managers.get_redis', return_value=RedisMock())
+    mocker.patch(
+        "concurrency_limit.context_managers.get_redis", return_value=RedisMock()
+    )
+
+    counter = 0
 
     @concurrent(threads=10_000)
     def _concurrent_function():
         with concurrency_limit.limit(
-                concurrency_limit.RedisConfiguration(),
-                concurrency_limit.LimitConfiguration(
-                    key='key-1',
-                    limit=500,
-                    limit_timeout=5,
-                ),
+            concurrency_limit.RedisConfiguration(),
+            concurrency_limit.LimitConfiguration(
+                key="key-1", limit=500, limit_timeout=1
+            ),
         ) as slot_id:
+            nonlocal counter
+
+            counter += 1
+
             assert 1 <= slot_id <= 500
-            time.sleep(1)
+            assert 1 <= counter <= 500
+
+            time.sleep(1.5)
+            counter -= 1
 
     with pytest.raises(concurrency_limit.ConcurrencyLimitException):
         _concurrent_function()
+
+
+def test_limit_clean(mocker: pytest_mock.MockerFixture):
+    client = RedisMock()
+    mocker.patch("concurrency_limit.context_managers.get_redis", return_value=client)
+
+    client.hset("key-1", "expired-1", int(time.time()) - 10)
+    client.hset("key-1", "expired-2", int(time.time()) - 10)
+    client.hset("key-1", "unexpired-1", int(time.time()) + 10)
+    client.hset("key-1", "unexpired-2", int(time.time()) + 10)
+
+    assert client.hlen("key-1") == 4
+    assert concurrency_limit.limit_clean(
+        concurrency_limit.RedisConfiguration(),
+        concurrency_limit.LimitConfiguration(key="key-1", limit=1),
+    ) == 2
+    assert client.hlen("key-1") == 2
+
+    for scan_key in concurrency_limit.limit_iter(concurrency_limit.RedisConfiguration(), "key-*"):
+        for scan_lock_id, _ in client.hscan_iter(scan_key):
+            assert scan_lock_id.startswith("unexpired-")


### PR DESCRIPTION
*Implemented changes:*
* Individual concurrency locks expire despite connection errors
* Minimum required version of `redis-py` is now `4.0`
* `black` formatting